### PR TITLE
feat: increase api-server throttling options

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -57,6 +57,12 @@ func Run(inputPaths []string, deployConfig utils.DeployConfig, opts *utils.Optio
 	restConfig, err := opts.Config.ToRESTConfig()
 	utils.CheckError(err)
 
+	// The following two options manage client-side throttling to decrease pressure on api-server
+	// Kubectl sets 300 bursts 50.0 QPS:
+	// https://github.com/kubernetes/kubectl/blob/0862c57c87184432986c85674a237737dabc53fa/pkg/cmd/cmd.go#L92
+	restConfig.QPS = 250.0
+	restConfig.Burst = 800
+
 	clients := &k8sClients{
 		dynamic:   dynamic.NewForConfigOrDie(restConfig),
 		discovery: discovery.NewDiscoveryClientForConfigOrDie(restConfig),


### PR DESCRIPTION
from some test on Kind:
23 resources: deployment, secret and cm

Same parameter as Kubectl:
```
restConfig.QPS = 50  
restConfig.Burst = 300
```  
**12.013s total**

```
restConfig.QPS = 250  
restConfig.Burst = 800  
```
**0.657s total**

This parameters drastically increase apply performance reducing request throttling client-side. I think that is a good trade-off, we are not building a general purpose tool like Kubectl, mlp interact with kubernetes only for applying yaml file.