### PR TITLE
fix: match as patch patch.ya?ml

### DIFF
--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -52,7 +52,7 @@ func findFiles(fs afero.Fs, overlay string) (map[fileType][]string, error) {
 		return nil, err
 	}
 
-	r, err := regexp.Compile(`\.patch\.ya?ml$`)
+	r, err := regexp.Compile(`(^|\.)patch\.ya?ml$`)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -79,6 +79,14 @@ func TestFindFiles(t *testing.T) {
 				Patch: {"myresource.patch.yaml", "myresource.patch.yml"},
 			},
 		},
+		{
+			desc:  "only patch.yaml",
+			input: []string{"patch.yaml", "patch.yml", "aaapatch.yaml", "aaapatch.yml"},
+			expected: map[fileType][]string{
+				Patch:    {"patch.yaml", "patch.yml"},
+				Resource: {"aaapatch.yaml", "aaapatch.yml"},
+			},
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {


### PR DESCRIPTION
fixes #20 accepting as patch also `patch.yaml`