### PR TITLE
feat: ignore patches already in kust.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- fix: match as patch patch.ya?ml
+### Fixes
+
+- match as patch patch.ya?ml
 - ignore patches already in kustomization.yaml
 
 ## [1.0.3] - 2022-02-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - fix: match as patch patch.ya?ml
+- ignore patches already in kustomization.yaml
 
 ## [1.0.3] - 2022-02-07
 

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -15,6 +15,7 @@
 package kustomize
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -122,6 +123,9 @@ func filterPatchinKust(files []string, fsys filesys.FileSystem) ([]string, error
 	// we are in the current directory
 	fileCont, err := fsys.ReadFile("kustomization.yaml")
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return files, nil
+		}
 		return nil, fmt.Errorf("error reading kustomization.yaml")
 	}
 	for k, f := range files {

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -15,7 +15,6 @@
 package kustomize
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -123,9 +122,6 @@ func filterPatchinKust(files []string, fsys filesys.FileSystem) ([]string, error
 	// we are in the current directory
 	fileCont, err := fsys.ReadFile("kustomization.yaml")
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return files, nil
-		}
 		return nil, fmt.Errorf("error reading kustomization.yaml")
 	}
 	for k, f := range files {

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -98,7 +98,7 @@ func execAdd(fsys filesys.FileSystem, path string, AllTypesFiles map[fileType][]
 		kustomizeCmd := resType.GetCommand()
 		if resType == Patch {
 			// Removes patches already present in kustomization.yaml
-			files, err = filterPatchinKust(files, fsys)
+			files, err = filterPatchFiles(files, fsys)
 			if err != nil {
 				return err
 			}
@@ -118,7 +118,7 @@ func remove(s []string, i int) []string {
 	return s[:len(s)-1]
 }
 
-func filterPatchinKust(files []string, fsys filesys.FileSystem) ([]string, error) {
+func filterPatchFiles(files []string, fsys filesys.FileSystem) ([]string, error) {
 	// we are in the current directory
 	fileCont, err := fsys.ReadFile("kustomization.yaml")
 	if err != nil {

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -98,7 +98,7 @@ func execAdd(fsys filesys.FileSystem, path string, AllTypesFiles map[fileType][]
 		kustomizeCmd := resType.GetCommand()
 		if resType == Patch {
 			// Removes patches already present in kustomization.yaml
-			files, err = checkPresence(files, fsys)
+			files, err = filterPatchinKust(files, fsys)
 			if err != nil {
 				return err
 			}
@@ -118,7 +118,7 @@ func remove(s []string, i int) []string {
 	return s[:len(s)-1]
 }
 
-func checkPresence(files []string, fsys filesys.FileSystem) ([]string, error) {
+func filterPatchinKust(files []string, fsys filesys.FileSystem) ([]string, error) {
 	// we are in the current directory
 	fileCont, err := fsys.ReadFile("kustomization.yaml")
 	if err != nil {

--- a/pkg/kustomize/kustomize.go
+++ b/pkg/kustomize/kustomize.go
@@ -15,6 +15,7 @@
 package kustomize
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -79,8 +80,6 @@ func findFiles(fs afero.Fs, overlay string) (map[fileType][]string, error) {
 
 // execute kustomize edit add command
 func execAdd(fsys filesys.FileSystem, path string, AllTypesFiles map[fileType][]string) error {
-	pvd := provider.NewDefaultDepProvider()
-
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -97,15 +96,50 @@ func execAdd(fsys filesys.FileSystem, path string, AllTypesFiles map[fileType][]
 	// Resource: kustomize resource add resource f
 	for resType, files := range AllTypesFiles {
 		kustomizeCmd := resType.GetCommand()
-		for _, f := range files {
-			editCmd := edit.NewCmdEdit(
-				fsys, pvd.GetFieldValidator(), pvd.GetResourceFactory(), os.Stdout)
-			editCmd.SetArgs(append(kustomizeCmd, f))
-			err := editCmd.Execute()
+		if resType == Patch {
+			// Removes patches already present in kustomization.yaml
+			files, err = checkPresence(files, fsys)
 			if err != nil {
 				return err
 			}
 		}
+		for _, f := range files {
+			err := executeCmd(f, kustomizeCmd, fsys)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func remove(s []string, i int) []string {
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
+}
+
+func checkPresence(files []string, fsys filesys.FileSystem) ([]string, error) {
+	// we are in the current directory
+	fileCont, err := fsys.ReadFile("kustomization.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("error reading kustomization.yaml")
+	}
+	for k, f := range files {
+		if strings.Contains(string(fileCont), f) {
+			files = remove(files, k)
+		}
+	}
+	return files, nil
+}
+
+func executeCmd(file string, kustomizeCmd []string, fsys filesys.FileSystem) error {
+	pvd := provider.NewDefaultDepProvider()
+	editCmd := edit.NewCmdEdit(
+		fsys, pvd.GetFieldValidator(), pvd.GetResourceFactory(), os.Stdout)
+	editCmd.SetArgs(append(kustomizeCmd, file))
+	err := editCmd.Execute()
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -161,7 +161,7 @@ func TestExecAdd(t *testing.T) {
 	}
 }
 
-func TestFilterPatchinKust(t *testing.T) {
+func TestFilterPatchFiles(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		expected      []string
@@ -180,7 +180,7 @@ func TestFilterPatchinKust(t *testing.T) {
 			fsys := filesys.MakeFsInMemory()
 			err := fsys.WriteFile("kustomization.yaml", []byte(tC.kustomization))
 			require.Nil(t, err)
-			actual, err := filterPatchinKust(tC.input, fsys)
+			actual, err := filterPatchFiles(tC.input, fsys)
 			require.Nil(t, err)
 			require.Equal(t, tC.expected, actual)
 		})

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -180,7 +180,7 @@ func TestCheckPresence(t *testing.T) {
 			fsys := filesys.MakeFsInMemory()
 			err := fsys.WriteFile("kustomization.yaml", []byte(tC.kustomization))
 			require.Nil(t, err)
-			actual, err := checkPresence(tC.input, fsys)
+			actual, err := filterPatchinKust(tC.input, fsys)
 			require.Nil(t, err)
 			require.Equal(t, tC.expected, actual)
 		})

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -161,7 +161,7 @@ func TestExecAdd(t *testing.T) {
 	}
 }
 
-func TestCheckPresence(t *testing.T) {
+func TestFilterPatchinKust(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		expected      []string
@@ -185,4 +185,11 @@ func TestCheckPresence(t *testing.T) {
 			require.Equal(t, tC.expected, actual)
 		})
 	}
+	t.Run("kustomization.yaml not existing", func(t *testing.T) {
+		fsys := filesys.MakeFsInMemory()
+		actual, err := filterPatchinKust([]string{"res-not-present.yaml"}, fsys)
+		expected := []string{"res-not-present.yaml"}
+		require.Nil(t, err)
+		require.Equal(t, expected, actual)
+	})
 }

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -185,11 +185,4 @@ func TestFilterPatchinKust(t *testing.T) {
 			require.Equal(t, tC.expected, actual)
 		})
 	}
-	t.Run("kustomization.yaml not existing", func(t *testing.T) {
-		fsys := filesys.MakeFsInMemory()
-		actual, err := filterPatchinKust([]string{"res-not-present.yaml"}, fsys)
-		expected := []string{"res-not-present.yaml"}
-		require.Nil(t, err)
-		require.Equal(t, expected, actual)
-	})
 }

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -141,3 +141,29 @@ func TestExecAdd(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckPresence(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		expected      []string
+		input         []string
+		kustomization string
+	}{
+		{
+			desc:          "some res in kustomization.yaml",
+			expected:      []string{"res-not-present.yaml"},
+			input:         []string{"resource1.service.yaml", "res-not-present.yaml"},
+			kustomization: "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\npatches:\n- path: deployment1.PATCH.yml\nresources:\n- resource1.service.yaml",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			fsys := filesys.MakeFsInMemory()
+			err := fsys.WriteFile("kustomization.yaml", []byte(tC.kustomization))
+			require.Nil(t, err)
+			actual, err := checkPresence(tC.input, fsys)
+			require.Nil(t, err)
+			require.Equal(t, tC.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
If a patch file is already present in `kustomization.yaml` mlp will not execute `kustomize resource add patch --path <file>` on that file