### PR TITLE
fix: no smartdeploy on first update

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -577,6 +577,11 @@ func ensureSmartDeploy(onClusterResource *unstructured.Unstructured, target *res
 		currentAnn = make(map[string]string)
 	}
 
+	depChecksum, found := currentAnn[resourceutil.GetMiaAnnotation(deployChecksum)]
+	if !found {
+		return nil
+	}
+
 	targetAnn, found, err := unstructured.NestedStringMap(target.Object.Object, path...)
 	if err != nil {
 		return err
@@ -584,7 +589,7 @@ func ensureSmartDeploy(onClusterResource *unstructured.Unstructured, target *res
 	if !found {
 		targetAnn = make(map[string]string)
 	}
-	targetAnn[resourceutil.GetMiaAnnotation(deployChecksum)] = currentAnn[resourceutil.GetMiaAnnotation(deployChecksum)]
+	targetAnn[resourceutil.GetMiaAnnotation(deployChecksum)] = depChecksum
 	err = unstructured.SetNestedStringMap(target.Object.Object, targetAnn, path...)
 	if err != nil {
 		return err

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -577,6 +577,8 @@ func ensureSmartDeploy(onClusterResource *unstructured.Unstructured, target *res
 		currentAnn = make(map[string]string)
 	}
 
+	// If deployChecksum annotation is not found early returns avoiding creating an
+	// empty annotation causing a pod restart
 	depChecksum, found := currentAnn[resourceutil.GetMiaAnnotation(deployChecksum)]
 	if !found {
 		return nil

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -468,10 +468,6 @@ func apply(clients *k8sClients, res resourceutil.Resource, deployConfig utils.De
 					if err := ensureDeployAll(&res, time.Now()); err != nil {
 						return errors.Wrap(err, "failed ensure deploy all on resource not using semver")
 					}
-				} else {
-					if err = ensureSmartDeploy(onClusterObj, &res); err != nil {
-						return errors.Wrap(err, "failed smart deploy ensure")
-					}
 				}
 			}
 
@@ -556,41 +552,6 @@ func createPatch(currentObj unstructured.Unstructured, target resourceutil.Resou
 
 	patch, err := strategicpatch.CreateThreeWayMergePatch([]byte(original), desired, current, patchMeta, true)
 	return patch, types.StrategicMergePatchType, err
-}
-
-// EnsureSmartDeploy merge, if present, the "mia-platform.eu/deploy-checksum" annotation from the Kubernetes cluster
-// into the target Resource that is going to be released.
-func ensureSmartDeploy(onClusterResource *unstructured.Unstructured, target *resourceutil.Resource) error {
-	var path []string
-	switch target.GroupVersionKind.Kind {
-	case "Deployment":
-		path = []string{"spec", "template", "metadata", "annotations"}
-	case "CronJob":
-		path = []string{"spec", "jobTemplate", "spec", "template", "metadata", "annotations"}
-	}
-
-	currentAnn, found, err := unstructured.NestedStringMap(onClusterResource.Object, path...)
-	if err != nil {
-		return err
-	}
-	if !found {
-		currentAnn = make(map[string]string)
-	}
-
-	targetAnn, found, err := unstructured.NestedStringMap(target.Object.Object, path...)
-	if err != nil {
-		return err
-	}
-	if !found {
-		targetAnn = make(map[string]string)
-	}
-	targetAnn[resourceutil.GetMiaAnnotation(deployChecksum)] = currentAnn[resourceutil.GetMiaAnnotation(deployChecksum)]
-	err = unstructured.SetNestedStringMap(target.Object.Object, targetAnn, path...)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func checkIfCreateJob(k8sClient dynamic.Interface, currentObj *unstructured.Unstructured, target resourceutil.Resource) error {

--- a/pkg/deploy/deploy_test.go
+++ b/pkg/deploy/deploy_test.go
@@ -409,64 +409,6 @@ func TestEnsureDeployAll(t *testing.T) {
 	})
 }
 
-func TestEnsureSmartDeploy(t *testing.T) {
-	expectedCheckSum := "6ab733c74e26e73bca78aa9c4c9db62664f339d9eefac51dd503c9ff0cf0c329"
-
-	t.Run("Add deployment deploy/checksum annotation", func(t *testing.T) {
-		targetObject, err := resourceutil.NewResources("testdata/test-deployment.yaml", "default")
-		require.Nil(t, err)
-		currentObj := targetObject[0].Object.DeepCopy()
-		unstructured.SetNestedStringMap(currentObj.Object, map[string]string{
-			"mia-platform.eu/deploy-checksum": expectedCheckSum,
-			"test":                            "test",
-		}, "spec", "template", "metadata", "annotations")
-		t.Logf("targetObj: %s\n", currentObj.Object)
-		err = ensureSmartDeploy(currentObj, &targetObject[0])
-		require.Nil(t, err)
-		targetAnn, _, err := unstructured.NestedStringMap(targetObject[0].Object.Object,
-			"spec", "template", "metadata", "annotations")
-		require.Nil(t, err)
-		require.Equal(t, targetAnn["mia-platform.eu/deploy-checksum"], expectedCheckSum)
-	})
-
-	t.Run("Add deployment without deploy/checksum annotation", func(t *testing.T) {
-		targetObject, err := resourceutil.NewResources("testdata/test-deployment.yaml", "default")
-		require.Nil(t, err)
-		currentObj := targetObject[0].Object.DeepCopy()
-		err =
-			unstructured.SetNestedStringMap(targetObject[0].Object.Object, map[string]string{
-				"test": "test",
-			}, "spec", "template", "annotations")
-		require.Nil(t, err)
-
-		err = ensureSmartDeploy(currentObj, &targetObject[0])
-		require.Nil(t, err)
-
-		targetAnn, _, err := unstructured.NestedStringMap(targetObject[0].Object.Object,
-			"spec", "template", "annotations")
-		require.Nil(t, err)
-		require.Equal(t, "test", targetAnn["test"])
-	})
-
-	t.Run("Add cronjob deploy/checksum annotation", func(t *testing.T) {
-		targetObject, err := resourceutil.NewResources("testdata/cronjob-test.cronjob.yml", "default")
-		require.Nil(t, err)
-		currentObj := targetObject[0].Object.DeepCopy()
-		unstructured.SetNestedStringMap(currentObj.Object, map[string]string{
-			"mia-platform.eu/deploy-checksum": expectedCheckSum,
-			"test":                            "test",
-		}, "spec", "jobTemplate", "spec", "template", "metadata", "annotations")
-		t.Logf("targetObj: %s\n", currentObj.Object)
-		err = ensureSmartDeploy(currentObj, &targetObject[0])
-
-		require.Nil(t, err)
-		targetAnn, _, err := unstructured.NestedStringMap(targetObject[0].Object.Object,
-			"spec", "jobTemplate", "spec", "template", "metadata", "annotations")
-		require.Nil(t, err)
-		require.Equal(t, targetAnn["mia-platform.eu/deploy-checksum"], expectedCheckSum)
-	})
-}
-
 func TestInsertDependencies(t *testing.T) {
 	var configMapMap = map[string]string{"configMap1": "aaa", "configMap2": "bbb", "configMapLongLoongLoooooooooooooooooooooooooooooooooooooooooooooong": "eee"}
 	var secretMap = map[string]string{"secret1": "ccc", "secret2": "ddd"}

--- a/pkg/deploy/testdata/integration/smart-deploy/stage1/test-deployment-1.yaml
+++ b/pkg/deploy/testdata/integration/smart-deploy/stage1/test-deployment-1.yaml
@@ -17,6 +17,8 @@ spec:
       creationTimestamp: null
       labels:
         app: test-deployment
+      annotations:
+        mia-platform.eu/deploy-checksum: ""
     spec:
       containers:
       - image: nginx


### PR DESCRIPTION
fix #22  
This function is not needed because the three-way merge in apply phase never removes annotations of on-cluster resources