### PR TITLE
fix: create patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - use `kind` in integration tests
 
+### Fixed
+
+- fixed a bug in `createPatch` that caused all annotations to be deleted in the resulting patch if the target resource was annotated with `kubectl.kubernetes.io/last-applied-configuration`
+
 ## [1.1.0] - 2022-03-17
 
 ### Changed

--- a/pkg/deploy/apply.go
+++ b/pkg/deploy/apply.go
@@ -335,8 +335,8 @@ func applyResource(clients *k8sClients, res resourceutil.Resource, deployConfig 
 	return nil
 }
 
-// annotateTargetResource annotates a given resource with corev1.LastAppliedConfigAnnotation
-func annotateTargetResource(res resourceutil.Resource) (unstructured.Unstructured, error) {
+// annotateWithLastApplied annotates a given resource with corev1.LastAppliedConfigAnnotation
+func annotateWithLastApplied(res resourceutil.Resource) (unstructured.Unstructured, error) {
 	annotatedRes := res.Object.DeepCopy()
 	annotations := annotatedRes.GetAnnotations()
 	if annotations == nil {
@@ -367,7 +367,7 @@ func createPatch(currentObj unstructured.Unstructured, target resourceutil.Resou
 	lastAppliedConfigJson := currentObj.GetAnnotations()[corev1.LastAppliedConfigAnnotation]
 
 	// Get the desired configuration
-	annotatedTarget, err := annotateTargetResource(target)
+	annotatedTarget, err := annotateWithLastApplied(target)
 	if err != nil {
 		return nil, types.StrategicMergePatchType, err
 	}

--- a/pkg/deploy/apply.go
+++ b/pkg/deploy/apply.go
@@ -321,8 +321,6 @@ func applyResource(clients *k8sClients, res resourceutil.Resource, deployConfig 
 				return errors.Wrap(err, "failed to create patch")
 			}
 
-			fmt.Printf("GENERATED PATCH: (%s) \n%s", patchType, patch)
-
 			if _, err := clients.dynamic.Resource(gvr).
 				Namespace(res.Object.GetNamespace()).
 				Patch(context.Background(),

--- a/pkg/deploy/apply_test.go
+++ b/pkg/deploy/apply_test.go
@@ -185,33 +185,7 @@ func TestCreatePatch(t *testing.T) {
 		require.Nil(t, err)
 	})
 
-	t.Run("same object => empty patch", func(t *testing.T) {
-		targetR, err := resourceutil.NewResources("testdata/test-deployment.yaml", "default")
-		require.Nil(t, err)
-
-		targetR[0].Object.SetAnnotations(map[string]string{
-			"original-annotation":   "value",
-			"original-annotation-2": "value",
-		})
-
-		lastAppliedJson, err := targetR[0].Object.MarshalJSON()
-		require.Nil(t, err)
-
-		onCluster := targetR[0].Object.DeepCopy()
-		onCluster.SetAnnotations(map[string]string{
-			"kubectl.kubernetes.io/last-applied-configuration": string(lastAppliedJson),
-			"original-annotation":                              "value",
-			"original-annotation-2":                            "value",
-		})
-
-		patch, patchType, err := createPatch(*onCluster, targetR[0])
-
-		require.Equal(t, "{}", string(patch), "patch should contain original-annotation")
-		require.Equal(t, patchType, types.StrategicMergePatchType)
-		require.Nil(t, err)
-	})
-
-	t.Run("runtime annotation => do not delete", func(t *testing.T) {
+	t.Run("Changes made on the cluster are kept", func(t *testing.T) {
 		targetR, err := resourceutil.NewResources("testdata/test-deployment.yaml", "default")
 		require.Nil(t, err)
 

--- a/pkg/deploy/integration_test.go
+++ b/pkg/deploy/integration_test.go
@@ -194,7 +194,7 @@ var _ = Describe("deploy on mock kubernetes", func() {
 			}
 
 			// Force deploy_all, lastapplied annotation should not be equals
-			err := doRun(clients, "test7", []string{"testdata/integration/smart-deploy/stage1"}, deployAll, currentTime)
+			err := doRun(clients, "test7", []string{"testdata/integration/smart-deploy/stage2"}, deployAll, currentTime)
 			Expect(err).NotTo(HaveOccurred())
 			deployment, err := clients.dynamic.Resource(gvrDeployments).
 				Namespace("test7").
@@ -205,7 +205,7 @@ var _ = Describe("deploy on mock kubernetes", func() {
 			lastApplied = thisLastApplied
 
 			// Another smart_deploy, should be identical to the previous
-			err = doRun(clients, "test7", []string{"testdata/integration/smart-deploy/stage1"}, deployConfig, currentTime)
+			err = doRun(clients, "test7", []string{"testdata/integration/smart-deploy/stage2"}, deployConfig, currentTime)
 			Expect(err).NotTo(HaveOccurred())
 			deployment, err = clients.dynamic.Resource(gvrDeployments).
 				Namespace("test7").

--- a/pkg/deploy/integration_test.go
+++ b/pkg/deploy/integration_test.go
@@ -194,7 +194,7 @@ var _ = Describe("deploy on mock kubernetes", func() {
 			}
 
 			// Force deploy_all, lastapplied annotation should not be equals
-			err := doRun(clients, "test7", []string{"testdata/integration/smart-deploy/stage2"}, deployAll, currentTime)
+			err := doRun(clients, "test7", []string{"testdata/integration/smart-deploy/stage1"}, deployAll, currentTime)
 			Expect(err).NotTo(HaveOccurred())
 			deployment, err := clients.dynamic.Resource(gvrDeployments).
 				Namespace("test7").
@@ -205,7 +205,7 @@ var _ = Describe("deploy on mock kubernetes", func() {
 			lastApplied = thisLastApplied
 
 			// Another smart_deploy, should be identical to the previous
-			err = doRun(clients, "test7", []string{"testdata/integration/smart-deploy/stage2"}, deployConfig, currentTime)
+			err = doRun(clients, "test7", []string{"testdata/integration/smart-deploy/stage1"}, deployConfig, currentTime)
 			Expect(err).NotTo(HaveOccurred())
 			deployment, err = clients.dynamic.Resource(gvrDeployments).
 				Namespace("test7").


### PR DESCRIPTION
Fix a bug in `createPatch` function that causes the deletetion of all the annotations when a target resource contains `kubectl.kubernetes.io/last-applied-configuration` as annotation