### PR TITLE
fix: delete before apply use namespaced API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fixed `delete-before-apply` annotation behaviour to call namespace-scoped API
+
 ## [1.2.3] - 2023-08-24
 
 ### Fixed

--- a/pkg/deploy/apply.go
+++ b/pkg/deploy/apply.go
@@ -79,6 +79,7 @@ func withDeletableResource(apply applyFunction) applyFunction {
 			fmt.Printf("Deleting resource %s before apply\n", res.Object.GetName())
 
 			err = clients.dynamic.Resource(gvr).
+				Namespace(res.Object.GetNamespace()).
 				Delete(context.TODO(), res.Object.GetName(), metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				return err


### PR DESCRIPTION
## What this PR is for?

This PR fixes the behavior  of the `delete-before-apply` annotation by using the namespaced API endpoint instead of the cluster one, thus requiring lower privilege to execute the action. 
