### PR TITLE
Improve file detection in hydrate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- improve file detection during hydrate command for already present file in kustomization files
+
 ## [v2.0.1] - 2025-03-18
 
 ### Changed

--- a/pkg/cmd/hydrate/hydrate.go
+++ b/pkg/cmd/hydrate/hydrate.go
@@ -163,8 +163,13 @@ func updateKustomize(ctx context.Context, fSys filesys.FileSystem, path string, 
 		return err
 	}
 
+	alreadyPresentFiles := k.Resources
+	for _, patch := range k.Patches {
+		alreadyPresentFiles = append(alreadyPresentFiles, patch.Path)
+	}
+
 	for _, resource := range resources {
-		if kf.GetPath() == filepath.Join(path, resource) || slices.Contains(k.Resources, resource) {
+		if kf.GetPath() == filepath.Join(path, resource) || slices.Contains(alreadyPresentFiles, resource) {
 			continue
 		}
 		logger.V(8).Info("adding resource", "path", resource)
@@ -177,8 +182,8 @@ func updateKustomize(ctx context.Context, fSys filesys.FileSystem, path string, 
 		}
 
 		found := false
-		for _, pp := range k.Patches {
-			if pp.Path == patch {
+		for _, path := range alreadyPresentFiles {
+			if path == patch {
 				found = true
 				break
 			}

--- a/pkg/cmd/hydrate/hydrate_test.go
+++ b/pkg/cmd/hydrate/hydrate_test.go
@@ -80,8 +80,10 @@ patches:
     version: v1
     kind: Deployment
 - path: test4.patch.yml
+- path: config-file.yaml
 - path: test2.patch.YAML
 resources:
+- test2.patch.yaml
 - Test1.YAML
 - test3.patches.YAML
 `
@@ -164,8 +166,12 @@ func testingInMemoryFSys(t *testing.T) filesys.FileSystem {
 	require.NoError(t, err)
 	err = fSys.WriteFile(filepath.Join(overlaysFolder, "test4.patch.yml"), []byte{})
 	require.NoError(t, err)
+	err = fSys.WriteFile(filepath.Join(overlaysFolder, "config-file.yaml"), []byte{})
+	require.NoError(t, err)
 	err = fSys.WriteFile(filepath.Join(overlaysFolder, "kustomization.yml"), []byte(`kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+- test2.patch.yaml
 patches:
 - path: path.yaml
   target:
@@ -173,6 +179,7 @@ patches:
     version: v1
     kind: Deployment
 - path: test4.patch.yml
+- path: config-file.yaml
 `))
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

This PR is aimed at improving the detection of already present file path inside kustiomize files during the `hydrate` command. This will avoid to add files not marked as patch but added as patches to be added as resources and vice versa.
