### PR TITLE
feat: add timeout flag to deploy command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- add timeout flag to `mlp deploy` command
+
 ## [v2.2.0] - 2025-09-04
 
 ### Changed

--- a/pkg/cmd/deploy/deploy.go
+++ b/pkg/cmd/deploy/deploy.go
@@ -73,6 +73,10 @@ const (
 	dryRunDefaultValue = false
 	dryRunFlagUsage    = "if true the resources will be sent to the cluster but not persisted"
 
+	timeoutFlagName     = "timeout"
+	timeoutDefaultValue = 0 * time.Second
+	timeoutFlagUsage    = "the length of time to wait before giving up on waiting for the resources to be ready. 0 means no timeout."
+
 	stdinToken    = "-"
 	fieldManager  = "mlp"
 	inventoryName = "eu.mia-platform.mlp"
@@ -93,6 +97,7 @@ type Flags struct {
 	deployType      string
 	forceDeploy     bool
 	ensureNamespace bool
+	timeout         time.Duration
 	dryRun          bool
 }
 
@@ -102,6 +107,7 @@ type Options struct {
 	deployType      string
 	forceDeploy     bool
 	ensureNamespace bool
+	timeout         time.Duration
 	dryRun          bool
 
 	clientFactory util.ClientFactory
@@ -169,6 +175,7 @@ func (f *Flags) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&f.deployType, deployTypeFlagName, deployTypeDefaultValue, deployTypeFlagUsage)
 	flags.BoolVar(&f.forceDeploy, forceDeployFlagName, forceDeployDefaultValue, forceDeployFlagUsage)
 	flags.BoolVar(&f.ensureNamespace, ensureNamespaceFlagName, ensureNamespaceDefaultValue, ensureNamespaceFlagUsage)
+	flags.DurationVar(&f.timeout, timeoutFlagName, timeoutDefaultValue, timeoutFlagUsage)
 	flags.BoolVar(&f.dryRun, dryRunFlagName, dryRunDefaultValue, dryRunFlagUsage)
 }
 
@@ -183,6 +190,7 @@ func (f *Flags) ToOptions(reader io.Reader, writer io.Writer) (*Options, error) 
 		deployType:      f.deployType,
 		forceDeploy:     f.forceDeploy,
 		ensureNamespace: f.ensureNamespace,
+		timeout:         f.timeout,
 
 		clientFactory: util.NewFactory(f.ConfigFlags),
 		reader:        reader,
@@ -252,6 +260,7 @@ func (o *Options) Run(ctx context.Context) error {
 	opts := client.ApplierOptions{
 		FieldManager: fieldManager,
 		DryRun:       o.dryRun,
+		Timeout:      o.timeout,
 	}
 
 	logger.V(3).Info("start applying resources")


### PR DESCRIPTION
## What this PR is for?

Add a timeout flag for the `deploy` command for setting a max duration for waiting that alla resources are current.

**Which issue(s) this PR fixes:**
<!--
Link any associated issues with this PR for automatically close them when the PR is merged. You can reference them
with only `#<issue number>` or via the full link to the issue.
-->
- Fixes #
