### PR TITLE
feat: add recursive flag to interpolate command

### DIFF
--- a/pkg/cmd/interpolate/interpolate.go
+++ b/pkg/cmd/interpolate/interpolate.go
@@ -75,6 +75,11 @@ const (
 	allowMissingFilenamesFlagUsage   = "set to allow missing input filenames"
 	allowMissingFilenamesFlagDefault = false
 
+	recursiveFlagName    = "recursive"
+	recursiveFlagShort   = "r"
+	recursiveFlagUsage   = "recursively interpolate files in subdirectories"
+	recursiveFlagDefault = false
+
 	outputFlagName  = "out"
 	outputFlagShort = "o"
 	outputFlagUsage = "output directory where interpolated files are saved"
@@ -97,6 +102,7 @@ type Flags struct {
 	prefixes              []string
 	inputPaths            []string
 	allowMissingFilenames bool
+	recursive             bool
 	outputPath            string
 }
 
@@ -105,6 +111,7 @@ type Options struct {
 	prefixes              []string
 	inputPaths            []string
 	allowMissingFilenames bool
+	recursive             bool
 	outputPath            string
 	fSys                  filesys.FileSystem
 	reader                io.Reader
@@ -139,6 +146,7 @@ func (f *Flags) AddFlags(flags *pflag.FlagSet) {
 	flags.StringSliceVarP(&f.prefixes, prefixesFlagName, prefixesFlagShort, nil, prefixesFlagUsage)
 	flags.StringSliceVarP(&f.inputPaths, inputFlagName, inputFlagShort, nil, inputFlagUsage)
 	flags.BoolVar(&f.allowMissingFilenames, allowMissingFilenamesFlagName, allowMissingFilenamesFlagDefault, allowMissingFilenamesFlagUsage)
+	flags.BoolVarP(&f.recursive, recursiveFlagName, recursiveFlagShort, recursiveFlagDefault, recursiveFlagUsage)
 	flags.StringVarP(&f.outputPath, outputFlagName, outputFlagShort, "interpolated-files", outputFlagUsage)
 	if err := cobra.MarkFlagDirname(flags, outputFlagName); err != nil {
 		panic(err)
@@ -151,6 +159,7 @@ func (f *Flags) ToOptions(reader io.Reader, fSys filesys.FileSystem) (*Options, 
 		inputPaths:            f.inputPaths,
 		prefixes:              f.prefixes,
 		allowMissingFilenames: f.allowMissingFilenames,
+		recursive:             f.recursive,
 		outputPath:            f.outputPath,
 		fSys:                  fSys,
 		reader:                reader,
@@ -193,8 +202,20 @@ func (o *Options) Run(ctx context.Context) error {
 			return err
 		}
 
+		outputName := name
+		if o.recursive && path != stdinToken {
+			outputName = o.relativeOutputName(path)
+		}
+
+		outputFile := filepath.Join(o.outputPath, outputName)
+		if dir := filepath.Dir(outputFile); dir != o.outputPath {
+			if err := o.fSys.MkdirAll(dir); err != nil {
+				return err
+			}
+		}
+
 		logger.V(10).Info("saving interpolated file", "path", path)
-		if err := o.fSys.WriteFile(filepath.Join(o.outputPath, name), interpolatedData); err != nil {
+		if err := o.fSys.WriteFile(outputFile, interpolatedData); err != nil {
 			return err
 		}
 	}
@@ -241,8 +262,11 @@ func (o *Options) filesToInterpolate(ctx context.Context) ([]string, error) {
 				return err
 			}
 			if info.IsDir() && walkPath != path {
-				logger.V(10).Info("ignore folder inside a folder", "path", walkPath)
-				return fs.SkipDir
+				if !o.recursive {
+					logger.V(10).Info("ignore folder inside a folder", "path", walkPath)
+					return fs.SkipDir
+				}
+				return nil
 			}
 
 			addOnlyYAMLFiles(walkPath)
@@ -265,6 +289,17 @@ func (o *Options) readFile(path string) ([]byte, string, error) {
 
 	data, err := o.fSys.ReadFile(path)
 	return data, filepath.Base(path), err
+}
+
+func (o *Options) relativeOutputName(filePath string) string {
+	for _, inputPath := range o.inputPaths {
+		rel, err := filepath.Rel(inputPath, filePath)
+		if err == nil && !strings.HasPrefix(rel, "..") {
+			return rel
+		}
+	}
+
+	return filepath.Base(filePath)
 }
 
 // Interpolate will interpolate the data content with values from env values

--- a/pkg/cmd/interpolate/interpolate_test.go
+++ b/pkg/cmd/interpolate/interpolate_test.go
@@ -119,6 +119,17 @@ ZZZZZZZZZZZZZZZZZZZZZZZZZZ
 			},
 			expectedResultsPath: filepath.Join(testdata, "results-contained"),
 		},
+		"interpolate recursive": {
+			option: &Options{
+				prefixes:   []string{"MLP_TEST_", "MLP_"},
+				inputPaths: []string{filepath.Join(testdata, "folder")},
+				recursive:  true,
+				outputPath: filepath.Join(testTmpDir, "outputs-recursive"),
+				fSys:       fSys,
+				reader:     new(bytes.Buffer),
+			},
+			expectedResultsPath: filepath.Join(testdata, "results-recursive"),
+		},
 		"interpolate from reader": {
 			option: &Options{
 				prefixes:   []string{"MLP_"},

--- a/pkg/cmd/interpolate/testdata/results-recursive/inner/inner.yaml
+++ b/pkg/cmd/interpolate/testdata/results-recursive/inner/inner.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inner
+data:
+  key: value

--- a/pkg/cmd/interpolate/testdata/results-recursive/no-interpolation.yaml
+++ b/pkg/cmd/interpolate/testdata/results-recursive/no-interpolation.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: example
+spec:
+  selector:
+    app: example
+  ports:
+  - port: 80
+    targetPort: 8080

--- a/pkg/cmd/interpolate/testdata/results-recursive/other-file.yml
+++ b/pkg/cmd/interpolate/testdata/results-recursive/other-file.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example
+data:
+  key: "{\"type\":\"type\",\"project_id\":\"id\",\"private_key_id\":\"key\",\"private_key\":\"-----BEGIN CERTIFICATE-----\nXXXXXXXXXXXXXXXXXXXXXXXXX\nYYYYYYYYYYYYYYY/4YYYYYYYYY\n-----END CERTIFICATE-----\n\",\"client_email\":\"email@example.com\",\"client_id\":\"client-id\",\"auth_uri\":\"https://example.com/auth\",\"token_uri\":\"https://example.com/token\",\"auth_provider_x509_cert_url\":\"https://example.com/certs\",\"client_x509_cert_url\":\"https://example.com/certs/fooo%40bar\"}"
+  key2: -----BEGIN CERTIFICATE-----\nXXXXXXXXXXXXXXXXXXXXXXXXX\nYYYYYYYYYYYYYYY/4YYYYYYYYY\nZZZZZZZZZZZZZZZZZZZZZZZZZZ\n-----END CERTIFICATE-----
+  key3: env\\first\line
+  key4: "$contains$dollars$otherstring"
+  key5: "otherstringtest"
+  key6: $contains$dollars$


### PR DESCRIPTION
## Description:

This PR adds a `--recursive` (`-r`) flag to the `interpolate` command, allowing it to recursively process files in subdirectories.

### Changes

- Added `--recursive` / `-r` boolean flag to the interpolate command
- When enabled, subdirectories are walked recursively instead of being skipped
- Output preserves the relative directory structure from input paths
- Added `relativeOutputName` helper to compute relative output paths
- Added test case and expected test data for recursive interpolation

### Notes

- Without `--recursive`, behavior is unchanged (subdirectories are skipped)
- Output directories are created automatically via `MkdirAll`
